### PR TITLE
feat: support auto dark mode through media queries

### DIFF
--- a/src/themes/github/index.css
+++ b/src/themes/github/index.css
@@ -93,3 +93,13 @@
 .callout-fold-icon {
   margin-left: -2px;
 }
+
+@media (prefers-color-scheme: dark) {
+  .callout {
+    border-left-color: var(--rc-color-dark, var(--rc-color-default));
+  }
+
+  .callout-title {
+    color: var(--rc-color-dark, var(--rc-color-default));
+  }
+}

--- a/src/themes/obsidian/index.css
+++ b/src/themes/obsidian/index.css
@@ -217,3 +217,14 @@
   width: 18px;
   height: 18px;
 }
+
+@media (prefers-color-scheme: dark) {
+  .callout {
+    mix-blend-mode: lighten;
+    background-color: rgb(from var(--rc-color-dark, var(--rc-color-default)) r g b / 0.1);
+  }
+
+  .callout-title {
+    color: var(--rc-color-dark, var(--rc-color-default));
+  }
+}

--- a/src/themes/vitepress/index.css
+++ b/src/themes/vitepress/index.css
@@ -99,3 +99,9 @@
   height: 16px;
   stroke-width: 2.2;
 }
+
+@media (prefers-color-scheme: dark) {
+  .callout {
+    background-color: rgb(from var(--rc-color-dark, var(--rc-color-default)) r g b / 0.16);
+  }
+}


### PR DESCRIPTION
I just added rehype-callouts to my blog site which uses Svelte and TailwindCSS.
I really like this plugin, but because my site supports both light and dark mode, I couldn't find a way to easily enable and disable the `.dark` class used by the provided themes without introducing ugly javascript.

So, for use-cases like mine where the user expects to drop the plugin into something like mdsvex, `@import` a theme, and see the callouts in both light and dark mode, it makes sense to automatically apply dark mode styling with a media query.

The `.dark` class is of course still available for cases where the site is in dark mode regardless of user preference.

Thanks for this plugin! I found it to be a much better solution than the other alternatives.