### PR TITLE
fix: revert media query dark mode styles introduced in #32

### DIFF
--- a/src/themes/github/index.css
+++ b/src/themes/github/index.css
@@ -93,13 +93,3 @@
 .callout-fold-icon {
   margin-left: -2px;
 }
-
-@media (prefers-color-scheme: dark) {
-  .callout {
-    border-left-color: var(--rc-color-dark, var(--rc-color-default));
-  }
-
-  .callout-title {
-    color: var(--rc-color-dark, var(--rc-color-default));
-  }
-}

--- a/src/themes/obsidian/index.css
+++ b/src/themes/obsidian/index.css
@@ -217,14 +217,3 @@
   width: 18px;
   height: 18px;
 }
-
-@media (prefers-color-scheme: dark) {
-  .callout {
-    mix-blend-mode: lighten;
-    background-color: rgb(from var(--rc-color-dark, var(--rc-color-default)) r g b / 0.1);
-  }
-
-  .callout-title {
-    color: var(--rc-color-dark, var(--rc-color-default));
-  }
-}

--- a/src/themes/vitepress/index.css
+++ b/src/themes/vitepress/index.css
@@ -99,9 +99,3 @@
   height: 16px;
   stroke-width: 2.2;
 }
-
-@media (prefers-color-scheme: dark) {
-  .callout {
-    background-color: rgb(from var(--rc-color-dark, var(--rc-color-default)) r g b / 0.16);
-  }
-}


### PR DESCRIPTION
The change in #32 caused callouts to appear in dark mode even when the site was set to light mode using class-based theming. This restores the previous behavior from v2.0.2. 

If you use media-query-based theming, you can stay on v2.1.0 or copy the styles into your own project.

Closes #36